### PR TITLE
Update Customization syntax in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ label.attributedText = markdownParser.parse(markdown)
 ## Customization
 
 ```swift
-let markdownParser = MarkdownParser(font: UIFont.systemFontOfSize(18))
+let markdownParser = MarkdownParser(font: UIFont.systemFont(ofSize: 18))
 markdownParser.enabledElements = .disabledAutomaticLink
-markdownParser.bold.color = UIColor.redColor()
-markdownParser.italic.font = UIFont.italicSystemFontOfSize(300)
+markdownParser.bold.color = UIColor.red
+markdownParser.italic.font = UIFont.italicSystemFont(ofSize: 300)
 markdownParser.header.fontIncrease = 4
 ```
 


### PR DESCRIPTION
The example customization syntax was out of date with the latest versions of Swift / UIKit.

This PR is an update to those docs. 