### PR TITLE
Fix Xcode 10.2 warnings

### DIFF
--- a/MarkdownKit/Sources/AppKit/Elements/Code/MarkdownCode+AppKit.swift
+++ b/MarkdownKit/Sources/AppKit/Elements/Code/MarkdownCode+AppKit.swift
@@ -8,7 +8,7 @@
 import AppKit
 
 public extension MarkdownCode {
-  public static let defaultHighlightColor = MarkdownColor(red: 0.90, green: 0.20, blue: 0.40, alpha: 1.0)
-  public static let defaultBackgroundColor = MarkdownColor(red: 0.85, green: 0.85, blue: 0.85, alpha: 1.0)
-  public static let defaultFont = MarkdownFont(name: "Menlo-Regular", size: 16)
+  static let defaultHighlightColor = MarkdownColor(red: 0.90, green: 0.20, blue: 0.40, alpha: 1.0)
+  static let defaultBackgroundColor = MarkdownColor(red: 0.85, green: 0.85, blue: 0.85, alpha: 1.0)
+  static let defaultFont = MarkdownFont(name: "Menlo-Regular", size: 16)
 }

--- a/MarkdownKit/Sources/AppKit/Elements/Header/MarkdownHeader+AppKit.swift
+++ b/MarkdownKit/Sources/AppKit/Elements/Header/MarkdownHeader+AppKit.swift
@@ -9,5 +9,5 @@
 import AppKit
 
 public extension MarkdownHeader {
-  public static let defaultFont = NSFont.boldSystemFont(ofSize: NSFont.systemFontSize)
+  static let defaultFont = NSFont.boldSystemFont(ofSize: NSFont.systemFontSize)
 }

--- a/MarkdownKit/Sources/AppKit/Elements/Link/MarkdownLink+AppKit.swift
+++ b/MarkdownKit/Sources/AppKit/Elements/Link/MarkdownLink+AppKit.swift
@@ -9,5 +9,5 @@
 import AppKit
 
 public extension MarkdownLink {
-  public static let defaultColor = NSColor.blue
+  static let defaultColor = NSColor.blue
 }

--- a/MarkdownKit/Sources/AppKit/Extensions/MarkdownFont+Traits.swift
+++ b/MarkdownKit/Sources/AppKit/Extensions/MarkdownFont+Traits.swift
@@ -9,15 +9,15 @@
 import AppKit
 
 public extension MarkdownFont {
-  public func italic() -> MarkdownFont {
+  func italic() -> MarkdownFont {
     return NSFontManager().convert(self, toHaveTrait: NSFontTraitMask.italicFontMask)
   }
   
-  public func bold() -> MarkdownFont {
+  func bold() -> MarkdownFont {
     return NSFontManager().convert(self, toHaveTrait: NSFontTraitMask.boldFontMask)
   }
   
-  public func withSize(_ size: CGFloat) -> NSFont {
+  func withSize(_ size: CGFloat) -> NSFont {
     return NSFontManager().convert(self, toSize: size)
   }
 }

--- a/MarkdownKit/Sources/AppKit/MarkdownParser+AppKit.swift
+++ b/MarkdownKit/Sources/AppKit/MarkdownParser+AppKit.swift
@@ -9,6 +9,6 @@
 import AppKit
 
 public extension MarkdownParser {
-  public static let defaultFont = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
-  public static let defaultColor = NSColor.black
+  static let defaultFont = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
+  static let defaultColor = NSColor.black
 }

--- a/MarkdownKit/Sources/Common/MarkdownParser.swift
+++ b/MarkdownKit/Sources/Common/MarkdownParser.swift
@@ -111,7 +111,7 @@ open class MarkdownParser {
   }
   
   open func removeCustomElement(_ element: MarkdownElement) {
-    guard let index = customElements.index(where: { someElement -> Bool in
+    guard let index = customElements.firstIndex(where: { someElement -> Bool in
       return element === someElement
     }) else {
       return

--- a/MarkdownKit/Sources/UIKit/Elements/Code/MarkdownCode+UIKit.swift
+++ b/MarkdownKit/Sources/UIKit/Elements/Code/MarkdownCode+UIKit.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 public extension MarkdownCode {
-  public static let defaultHighlightColor = UIColor(red: 0.90, green: 0.20, blue: 0.40, alpha: 1.0)
-  public static let defaultBackgroundColor = UIColor(red: 0.85, green: 0.85, blue: 0.85, alpha: 1.0)
-  public static let defaultFont = UIFont(name: "Menlo-Regular", size: 16)
+  static let defaultHighlightColor = UIColor(red: 0.90, green: 0.20, blue: 0.40, alpha: 1.0)
+  static let defaultBackgroundColor = UIColor(red: 0.85, green: 0.85, blue: 0.85, alpha: 1.0)
+  static let defaultFont = UIFont(name: "Menlo-Regular", size: 16)
 }

--- a/MarkdownKit/Sources/UIKit/Elements/Header/MarkdownHeader+UIKit.swift
+++ b/MarkdownKit/Sources/UIKit/Elements/Header/MarkdownHeader+UIKit.swift
@@ -9,5 +9,5 @@
 import UIKit
 
 public extension MarkdownHeader {
-  public static let defaultFont = UIFont.boldSystemFont(ofSize: UIFont.smallSystemFontSize)
+  static let defaultFont = UIFont.boldSystemFont(ofSize: UIFont.smallSystemFontSize)
 }

--- a/MarkdownKit/Sources/UIKit/Elements/Link/MarkdownLink+UIKit.swift
+++ b/MarkdownKit/Sources/UIKit/Elements/Link/MarkdownLink+UIKit.swift
@@ -9,5 +9,5 @@
 import UIKit
 
 public extension MarkdownLink {
-  public static let defaultColor = UIColor.blue
+  static let defaultColor = UIColor.blue
 }

--- a/MarkdownKit/Sources/UIKit/MarkdownParser+UIKit.swift
+++ b/MarkdownKit/Sources/UIKit/MarkdownParser+UIKit.swift
@@ -9,6 +9,6 @@
 import UIKit
 
 public extension MarkdownParser {
-  public static let defaultFont = UIFont.systemFont(ofSize: UIFont.smallSystemFontSize)
-  public static let defaultColor = UIColor.black
+  static let defaultFont = UIFont.systemFont(ofSize: UIFont.smallSystemFontSize)
+  static let defaultColor = UIColor.black
 }


### PR DESCRIPTION
>'public' modifier is redundant for static property declared in a public extension
>'index(where:)' is deprecated: renamed to 'firstIndex(where:)'