### PR TITLE
Alignment with new Swift API

### DIFF
--- a/MarkdownKit/Sources/Common/MarkdownParser.swift
+++ b/MarkdownKit/Sources/Common/MarkdownParser.swift
@@ -111,7 +111,7 @@ open class MarkdownParser {
   }
   
   open func removeCustomElement(_ element: MarkdownElement) {
-    guard let index = customElements.index(where: { someElement -> Bool in
+    guard let index = customElements.firstIndex(where: { someElement -> Bool in
       return element === someElement
     }) else {
       return


### PR DESCRIPTION
index(where:) is mark as deprecated. Replacing by firstIndex(where:)