### PR TITLE
Replace mega bullet with a normal bullet

### DIFF
--- a/MarkdownKit/Sources/Common/Elements/List/MarkdownList.swift
+++ b/MarkdownKit/Sources/Common/Elements/List/MarkdownList.swift
@@ -22,7 +22,7 @@ open class MarkdownList: MarkdownLevelElement {
     return String(format: MarkdownList.regex, level)
   }
 
-  public init(font: MarkdownFont? = nil, maxLevel: Int = 6, indicator: String = "●",
+  public init(font: MarkdownFont? = nil, maxLevel: Int = 6, indicator: String = "•",
               separator: String = "  ", color: MarkdownColor? = nil) {
     self.maxLevel = maxLevel
     self.indicator = indicator


### PR DESCRIPTION

Hey,

I have plugged in MarkdownKit into my app today & found that the bullet are gigantic. This PR replaces the mega bullet with a normal size bullet.

<img width="850" alt="Screen Shot 2020-09-25 at 20 19 31" src="https://user-images.githubusercontent.com/704044/94302384-6ee0d280-ff6c-11ea-96bb-b48f48c69635.png">

Cheers,
Andrej

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bmoliveira/markdownkit/74)
<!-- Reviewable:end -->
