### PR TITLE
Fix build for macCatalyst

### DIFF
--- a/MarkdownKit/Sources/AppKit/Elements/Code/MarkdownCode+AppKit.swift
+++ b/MarkdownKit/Sources/AppKit/Elements/Code/MarkdownCode+AppKit.swift
@@ -5,7 +5,7 @@
 //  Created by Bruno Oliveira on 31/01/2019.
 //  Copyright © 2019 Ivan Bruel. All rights reserved.
 //
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 
 import AppKit
 

--- a/MarkdownKit/Sources/AppKit/Elements/Header/MarkdownHeader+AppKit.swift
+++ b/MarkdownKit/Sources/AppKit/Elements/Header/MarkdownHeader+AppKit.swift
@@ -5,7 +5,7 @@
 //  Created by Bruno Oliveira on 31/01/2019.
 //  Copyright © 2019 Ivan Bruel. All rights reserved.
 //
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 
 import AppKit
 

--- a/MarkdownKit/Sources/AppKit/Elements/Link/MarkdownLink+AppKit.swift
+++ b/MarkdownKit/Sources/AppKit/Elements/Link/MarkdownLink+AppKit.swift
@@ -5,7 +5,7 @@
 //  Created by Bruno Oliveira on 31/01/2019.
 //  Copyright © 2019 Ivan Bruel. All rights reserved.
 //
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 
 import AppKit
 

--- a/MarkdownKit/Sources/AppKit/Extensions/MarkdownFont+Traits.swift
+++ b/MarkdownKit/Sources/AppKit/Extensions/MarkdownFont+Traits.swift
@@ -5,7 +5,7 @@
 //  Created by Bruno Oliveira on 31/01/2019.
 //  Copyright © 2019 Ivan Bruel. All rights reserved.
 //
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 
 import AppKit
 

--- a/MarkdownKit/Sources/AppKit/MarkdownParser+AppKit.swift
+++ b/MarkdownKit/Sources/AppKit/MarkdownParser+AppKit.swift
@@ -5,7 +5,7 @@
 //  Created by Bruno Oliveira on 31/01/2019.
 //  Copyright © 2019 Ivan Bruel. All rights reserved.
 //
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 
 import AppKit
 


### PR DESCRIPTION
Currently library fails to build when targeting `Mac Catalyst` platform. It happens due to `canImport(AppKit)` pre-compile check which is `true` on `Mac Catalyst`, but many APIs like `NSFont` still are not available. This PR adds `targetEnvironment` checks.