### PR TITLE
Fix links and parentheses don't work well together 

### DIFF
--- a/MarkdownKit/Sources/Common/Elements/Bold/MarkdownBold.swift
+++ b/MarkdownKit/Sources/Common/Elements/Bold/MarkdownBold.swift
@@ -22,7 +22,7 @@ open class MarkdownBold: MarkdownCommonElement {
     self.font = font?.bold()
     self.color = color
   }
-  
+
   public func match(_ match: NSTextCheckingResult, attributedString: NSMutableAttributedString) {
     // deleting trailing markdown
     attributedString.deleteCharacters(in: match.range(at: 4))

--- a/MarkdownKit/Sources/Common/Elements/Italic/MarkdownItalic.swift
+++ b/MarkdownKit/Sources/Common/Elements/Italic/MarkdownItalic.swift
@@ -22,7 +22,7 @@ open class MarkdownItalic: MarkdownCommonElement {
     self.font = font?.italic()
     self.color = color
   }
-  
+    
   public func match(_ match: NSTextCheckingResult, attributedString: NSMutableAttributedString) {
     // deleting trailing markdown
     attributedString.deleteCharacters(in: match.range(at: 4))

--- a/MarkdownKit/Sources/Common/Elements/Link/MarkdownLink.swift
+++ b/MarkdownKit/Sources/Common/Elements/Link/MarkdownLink.swift
@@ -96,6 +96,6 @@ open class MarkdownLink: MarkdownLinkElement {
 
 fileprivate extension String {
 	func numberOfOccurrences(of string: String) -> Int {
-		return components(separatedBy: string).count - 1
+		return max(0, components(separatedBy: string).count - 1)
 	}
 }

--- a/MarkdownKit/Sources/Common/Elements/Link/MarkdownLink.swift
+++ b/MarkdownKit/Sources/Common/Elements/Link/MarkdownLink.swift
@@ -57,12 +57,23 @@ open class MarkdownLink: MarkdownLinkElement {
 
     let urlLinkAbsoluteStart = match.range.location
     
-    let linkURLString = nsString
+    var linkURLString = nsString
       .substring(with: NSRange(location: urlLinkAbsoluteStart + linkMatch.range.location + 1, length: linkMatch.range.length - 2))
+
+	let numberOfOpeningParentheses = linkURLString.numberOfOccurrences(of: "(")
+	let numberOfClosingParentheses = linkURLString.numberOfOccurrences(of: ")")
+	var numberOfExtraClosingParentheses = max(0, numberOfClosingParentheses - numberOfOpeningParentheses)
+
+	var numberOfChoppedOffCharacters = 0
+	while numberOfExtraClosingParentheses > 0 && linkURLString.hasSuffix(")") {
+		numberOfExtraClosingParentheses -= 1
+		numberOfChoppedOffCharacters += 1
+		linkURLString = String(linkURLString.dropLast())
+	}
     
     // deleting trailing markdown
     // needs to be called before formattingBlock to support modification of length
-    let trailingMarkdownRange = NSRange(location: urlLinkAbsoluteStart + linkMatch.range.location - 1, length: linkMatch.range.length + 1)
+    let trailingMarkdownRange = NSRange(location: urlLinkAbsoluteStart + linkMatch.range.location - 1, length: linkMatch.range.length + 1 - numberOfChoppedOffCharacters)
     attributedString.deleteCharacters(in: trailingMarkdownRange)
     
     // deleting leading markdown
@@ -81,4 +92,10 @@ open class MarkdownLink: MarkdownLinkElement {
                             link: String) {
     attributedString.addAttributes(attributes, range: range)
   }
+}
+
+fileprivate extension String {
+	func numberOfOccurrences(of string: String) -> Int {
+		return components(separatedBy: string).count - 1
+	}
 }

--- a/MarkdownKit/Sources/Common/Elements/Link/MarkdownLink.swift
+++ b/MarkdownKit/Sources/Common/Elements/Link/MarkdownLink.swift
@@ -10,10 +10,10 @@ import Foundation
 open class MarkdownLink: MarkdownLinkElement {
   
   fileprivate static let regex = "\\[[^\\]]+\\]\\(\\S+(?=\\))\\)"
-  
+
   // This regex is eager if does not count even trailing Parentheses.
-  fileprivate static let onlyLinkRegex = "\\(\\S+(?=\\))\\)"
-  
+  fileprivate static let onlyLinkRegex = "\\]\\(\\S+(?=\\))\\)"
+
   open var font: MarkdownFont?
   open var color: MarkdownColor?
   
@@ -33,11 +33,13 @@ open class MarkdownLink: MarkdownLinkElement {
   
   open func formatText(_ attributedString: NSMutableAttributedString, range: NSRange,
                          link: String) {
-    guard let encodedLink = link.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlHostAllowed)
+    let fullLink = link.starts(with: "http") ? link : "https://\(link)"
+
+    guard let encodedLink = fullLink.addingPercentEncoding(withAllowedCharacters: CharacterSet.urlHostAllowed)
       else {
       return
     }
-    guard let url = URL(string: link) ?? URL(string: encodedLink) else { return }
+    guard let url = URL(string: fullLink) ?? URL(string: encodedLink) else { return }
     attributedString.addAttribute(NSAttributedString.Key.link, value: url, range: range)
   }
   

--- a/MarkdownKit/Sources/Common/MarkdownParser.swift
+++ b/MarkdownKit/Sources/Common/MarkdownParser.swift
@@ -112,6 +112,11 @@ open class MarkdownParser {
     updateEscapingElements()
     updateUnescapingElements()
   }
+
+   public func replaceDefaultElement(_ defaultElement: MarkdownElement, with element: MarkdownElement) {
+	guard let index = defaultElements.firstIndex(where: {$0  === defaultElement}) else { return }
+	defaultElements[index] = element
+   }
   
   // MARK: Element Extensibility
   open func addCustomElement(_ element: MarkdownElement) {

--- a/MarkdownKit/Sources/Common/MarkdownParser.swift
+++ b/MarkdownKit/Sources/Common/MarkdownParser.swift
@@ -113,10 +113,10 @@ open class MarkdownParser {
     updateUnescapingElements()
   }
 
-   public func replaceDefaultElement(_ defaultElement: MarkdownElement, with element: MarkdownElement) {
-	guard let index = defaultElements.firstIndex(where: {$0  === defaultElement}) else { return }
+  public func replaceDefaultElement<E: MarkdownElement>(_ defaultElement: E.Type, with element: MarkdownElement) {
+    guard let index = defaultElements.firstIndex(where: { $0 is E }) else { return }
 	defaultElements[index] = element
-   }
+  }
   
   // MARK: Element Extensibility
   open func addCustomElement(_ element: MarkdownElement) {


### PR DESCRIPTION
Continues #79, Fixes #78

Summary by @AndreasVerhoeven  
> - we count the number of opening and closing parentheses in the link
> - if we have more closing parentheses than opening parentheses
> - AND if there are closing parentheses at the end of the link, we assume they should originally have been outside of the link and be part of the regular text 
 
> This seems to work well in practice: Almost all links with parentheses have them balanced (e.g. wikipedia links), and links surrounded by () now work correctly as well

I've fixed the merge conflicts and changed the replaceDefault method to use generics

In addition to that:
- Fixes an issues with inline parentheses of the link text and url
- Adds https as scheme if it is missing

Planning to add:
- Ability to provide a default scheme
