### PR TITLE
Improve links and preserve styles

### DIFF
--- a/Examples/iOS/MarkdownSubreddit.swift
+++ b/Examples/iOS/MarkdownSubreddit.swift
@@ -22,7 +22,7 @@ class MarkdownSubreddit: MarkdownLink {
     let subredditName = attributedString.attributedSubstring(from: match.range(at: 3)).string
     let linkURLString = "http://reddit.com/r/\(subredditName)"
     formatText(attributedString, range: match.range, link: linkURLString)
-    addAttributes(attributedString, range: match.range, link: linkURLString)
+    addAttributes(attributedString, range: match.range)
   }
   
 }

--- a/Examples/macOS/Base.lproj/Main.storyboard
+++ b/Examples/macOS/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.31"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -620,7 +620,7 @@
                                         <menuItem title="Show Sidebar" keyEquivalent="s" id="kIP-vf-haE">
                                             <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
                                             <connections>
-                                                <action selector="toggleSourceList:" target="Ady-hI-5gd" id="iwa-gc-5KM"/>
+                                                <action selector="toggleSidebar:" target="Ady-hI-5gd" id="iwa-gc-5KM"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Enter Full Screen" keyEquivalent="f" id="4J7-dP-txa">
@@ -675,7 +675,7 @@
                         <outlet property="delegate" destination="Voe-Tx-rLC" id="PrD-fu-P6m"/>
                     </connections>
                 </application>
-                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Example_AppKit" customModuleProvider="target"/>
+                <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Example_macOS" customModuleProvider="target"/>
                 <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
                 <customObject id="Ady-hI-5gd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -705,7 +705,7 @@
         <!--View Controller-->
         <scene sceneID="hIz-AP-VOD">
             <objects>
-                <viewController id="XfG-lQ-9wD" customClass="ViewController" customModule="Example_AppKit" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="XfG-lQ-9wD" customClass="ViewController" customModule="Example_macOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" wantsLayer="YES" id="m2S-Jp-Qdl">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="480"/>
                         <autoresizingMask key="autoresizingMask"/>
@@ -716,7 +716,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="600" height="480"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <textView editable="NO" selectable="NO" importsGraphics="NO" verticallyResizable="YES" findStyle="bar" spellingCorrection="YES" smartInsertDelete="YES" id="SGu-Re-lLv">
+                                        <textView editable="NO" importsGraphics="NO" verticallyResizable="YES" findStyle="bar" spellingCorrection="YES" smartInsertDelete="YES" id="SGu-Re-lLv">
                                             <rect key="frame" x="0.0" y="0.0" width="600" height="480"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -727,6 +727,10 @@
                                         </textView>
                                     </subviews>
                                 </clipView>
+                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="jM4-oA-HAt">
+                                    <rect key="frame" x="-100" y="-100" width="600" height="16"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
                                 <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="GEY-tc-eTy">
                                     <rect key="frame" x="584" y="0.0" width="16" height="480"/>
                                     <autoresizingMask key="autoresizingMask"/>

--- a/Examples/macOS/ViewController.swift
+++ b/Examples/macOS/ViewController.swift
@@ -12,13 +12,13 @@ import MarkdownKit
 class ViewController: NSViewController {
   @IBOutlet var label: NSTextView!
   
-  fileprivate lazy var viewModel: MarkdownKitViewModel = {
+  fileprivate lazy var viewModel: ViewModel = {
     // Example with custom font
     // fileprivate let markdownParser = MarkdownParser(font: UIFont(name: "Product Sans", size: UIFont.systemFontSize)!)
     let parser = MarkdownParser()
     //parser.addCustomElement(MarkdownSubreddit())
     
-    let viewModel = MarkdownKitViewModel(markdownParser: parser)
+    let viewModel = ViewModel(markdownParser: parser)
     viewModel.markdownAttributedStringChanged = { [weak self](attributtedString, error) in
       if let error = error {
         NSLog("Error requesting -> \(error)")

--- a/MarkdownKit/Sources/Common/Elements/Bold/MarkdownBold.swift
+++ b/MarkdownKit/Sources/Common/Elements/Bold/MarkdownBold.swift
@@ -13,7 +13,7 @@ open class MarkdownBold: MarkdownCommonElement {
 
   open var font: MarkdownFont?
   open var color: MarkdownColor?
-  
+
   open var regex: String {
     return MarkdownBold.regex
   }
@@ -26,17 +26,21 @@ open class MarkdownBold: MarkdownCommonElement {
   public func match(_ match: NSTextCheckingResult, attributedString: NSMutableAttributedString) {
     attributedString.deleteCharacters(in: match.range(at: 4))
 
-    var attributes = attributedString.attributes(
-        at: match.range(at: 3).location,
-        longestEffectiveRange: nil,
-        in: match.range(at: 3)
+    let currentAttributes = attributedString.attributes(
+      at: match.range(at: 3).location,
+      longestEffectiveRange: nil,
+      in: match.range(at: 3)
     )
 
-    if let font = attributes[.font] as? MarkdownFont {
-        attributes[NSAttributedString.Key.font] = font.bold()
-    }
+    addAttributes(attributedString, range: match.range(at: 3))
 
-    attributedString.addAttributes(attributes, range: match.range(at: 3))
+    if let font = currentAttributes[.font] as? MarkdownFont {
+      attributedString.addAttribute(
+        NSAttributedString.Key.font,
+        value: font.bold(),
+        range: match.range(at: 3)
+      )
+    }
 
     attributedString.deleteCharacters(in: match.range(at: 2))
   }

--- a/MarkdownKit/Sources/Common/Elements/Italic/MarkdownItalic.swift
+++ b/MarkdownKit/Sources/Common/Elements/Italic/MarkdownItalic.swift
@@ -9,7 +9,7 @@ import Foundation
 
 open class MarkdownItalic: MarkdownCommonElement {
   
-  fileprivate static let regex = "(.?|^)(\\*|_)(?=\\S)(.+?)(?<=\\S)(\\2)"
+  fileprivate static let regex = "(\\s|^)(\\*|_)(?![\\*_\\s])(.+?)(?<![\\*_\\s])(\\2)"
 
   open var font: MarkdownFont?
   open var color: MarkdownColor?

--- a/MarkdownKit/Sources/Common/Elements/Italic/MarkdownItalic.swift
+++ b/MarkdownKit/Sources/Common/Elements/Italic/MarkdownItalic.swift
@@ -26,17 +26,21 @@ open class MarkdownItalic: MarkdownCommonElement {
   public func match(_ match: NSTextCheckingResult, attributedString: NSMutableAttributedString) {
     attributedString.deleteCharacters(in: match.range(at: 4))
 
-    var attributes = attributedString.attributes(
-        at: match.range(at: 3).location,
-        longestEffectiveRange: nil,
-        in: match.range(at: 3)
+    let currentAttributes = attributedString.attributes(
+      at: match.range(at: 3).location,
+      longestEffectiveRange: nil,
+      in: match.range(at: 3)
     )
 
-    if let font = attributes[.font] as? MarkdownFont {
-        attributes[NSAttributedString.Key.font] = font.italic()
-    }
+    addAttributes(attributedString, range: match.range(at: 3))
 
-    attributedString.addAttributes(attributes, range: match.range(at: 3))
+    if let font = currentAttributes[.font] as? MarkdownFont {
+      attributedString.addAttribute(
+        NSAttributedString.Key.font,
+        value: font.italic(),
+        range: match.range(at: 3)
+      )
+    }
 
     attributedString.deleteCharacters(in: match.range(at: 2))
   }

--- a/MarkdownKit/Sources/Common/Elements/Link/MarkdownAutomaticLink.swift
+++ b/MarkdownKit/Sources/Common/Elements/Link/MarkdownAutomaticLink.swift
@@ -17,6 +17,6 @@ open class MarkdownAutomaticLink: MarkdownLink {
                              attributedString: NSMutableAttributedString) {
     let linkURLString = attributedString.attributedSubstring(from: match.range).string
     formatText(attributedString, range: match.range, link: linkURLString)
-    addAttributes(attributedString, range: match.range, link: linkURLString)
+    addAttributes(attributedString, range: match.range)
   }
 }

--- a/MarkdownKit/Sources/Common/Elements/Link/MarkdownLink.swift
+++ b/MarkdownKit/Sources/Common/Elements/Link/MarkdownLink.swift
@@ -6,7 +6,6 @@
 //
 //
 import Foundation
-import OSLog
 
 open class MarkdownLink: MarkdownLinkElement {
 
@@ -58,6 +57,7 @@ open class MarkdownLink: MarkdownLinkElement {
     let string = NSString(string: attributedString.string)
     var urlString = String(string.substring(with: NSRange(urlStart..<match.range(at: 2).upperBound - 2 )))
 
+    // Balance opening and closing parantheses inside the url
     var numberOfOpeningParantheses = 0
     var numberOfClosingParantheses = 0
     for (index, character) in urlString.enumerated() {
@@ -73,18 +73,35 @@ open class MarkdownLink: MarkdownLinkElement {
     }
 
     // Remove opening parantheses
-    attributedString.deleteCharacters(in: NSRange(location: match.range(at: 2).location  , length: 1))
+    attributedString.deleteCharacters(in: NSRange(location: match.range(at: 2).location, length: 1))
 
     // Remove closing parantheses
     let trailingMarkdownRange = NSRange(location: match.range(at: 2).location - 1, length: urlString.count + 1)
     attributedString.deleteCharacters(in: trailingMarkdownRange)
 
     let formatRange = NSRange(match.range(at: 1).location..<match.range(at: 2).location - 1)
+
+    // Add attributes while preserving current attributes
+
+    let currentAttributes = attributedString.attributes(
+      at: formatRange.location,
+      longestEffectiveRange: nil,
+      in: formatRange
+    )
+
+    addAttributes(attributedString, range: formatRange)
     formatText(attributedString, range: formatRange, link: urlString)
-    addAttributes(attributedString, range: formatRange, link: urlString)
+
+    if let font = currentAttributes[.font] as? MarkdownFont {
+      attributedString.addAttribute(
+        NSAttributedString.Key.font,
+        value: font,
+        range: formatRange
+      )
+    }
   }
 
-  open func addAttributes(_ attributedString: NSMutableAttributedString, range: NSRange, link: String) {
+  open func addAttributes(_ attributedString: NSMutableAttributedString, range: NSRange) {
     attributedString.addAttributes(attributes, range: range)
   }
 }

--- a/MarkdownKit/Sources/Common/Elements/Link/MarkdownLink.swift
+++ b/MarkdownKit/Sources/Common/Elements/Link/MarkdownLink.swift
@@ -58,15 +58,18 @@ open class MarkdownLink: MarkdownLinkElement {
     let string = NSString(string: attributedString.string)
     var urlString = String(string.substring(with: NSRange(urlStart..<match.range(at: 2).upperBound - 2 )))
 
-    // Determine url bounds by balancing opening and closing paranthesis
-    // Removes remaining extra closing parantheses
-    let numberOfOpeningParentheses = urlString.numberOfOccurrences(of: "(")
-    let numberOfClosingParentheses = urlString.numberOfOccurrences(of: ")")
-    var numberOfExtraClosingParentheses = max(0, numberOfClosingParentheses - numberOfOpeningParentheses)
-
-    while numberOfExtraClosingParentheses > 0 && urlString.hasSuffix(")") {
-      numberOfExtraClosingParentheses -= 1
-      urlString = String(urlString.dropLast())
+    var numberOfOpeningParantheses = 0
+    var numberOfClosingParantheses = 0
+    for (index, character) in urlString.enumerated() {
+        switch character {
+        case "(": numberOfOpeningParantheses += 1
+        case ")": numberOfClosingParantheses += 1
+        default: continue
+        }
+        if numberOfClosingParantheses > numberOfOpeningParantheses {
+            urlString = NSString(string: urlString).substring(with: NSRange(0..<index))
+            break
+        }
     }
 
     // Remove opening parantheses
@@ -84,10 +87,4 @@ open class MarkdownLink: MarkdownLinkElement {
   open func addAttributes(_ attributedString: NSMutableAttributedString, range: NSRange, link: String) {
     attributedString.addAttributes(attributes, range: range)
   }
-}
-
-fileprivate extension String {
-    func numberOfOccurrences(of string: String) -> Int {
-        return max(0, components(separatedBy: string).count - 1)
-    }
 }

--- a/MarkdownKit/Sources/Common/MarkdownParser.swift
+++ b/MarkdownKit/Sources/Common/MarkdownParser.swift
@@ -156,11 +156,11 @@ open class MarkdownParser {
       (.header, header),
       (.list, list),
       (.quote, quote),
-      (.link, link),
-      (.automaticLink, automaticLink),
       (.strikethrough, strikethrough),
       (.bold, bold),
       (.italic, italic),
+      (.link, link),
+      (.automaticLink, automaticLink),
       (.code, code),
     ]
     defaultElements = pairs.compactMap { enabled, element in

--- a/MarkdownKit/Sources/Common/MarkdownParser.swift
+++ b/MarkdownKit/Sources/Common/MarkdownParser.swift
@@ -58,7 +58,7 @@ open class MarkdownParser {
   public let italic: MarkdownItalic
   public let code: MarkdownCode
   public let strikethrough: MarkdownStrikethrough
-  
+
   // MARK: Escaping Elements
   fileprivate var codeEscaping = MarkdownCodeEscaping()
   fileprivate var escaping = MarkdownEscaping()
@@ -78,7 +78,7 @@ open class MarkdownParser {
   public let color: MarkdownColor
   
   // MARK: Legacy Initializer
-  @available(*, deprecated, renamed: "init", message: "This constructor will be removed soon, please use the new opions constructor")
+  @available(*, deprecated, renamed: "init", message: "This constructor will be removed soon, please use the new options constructor")
   public convenience init(automaticLinkDetectionEnabled: Bool,
                           font: MarkdownFont = MarkdownParser.defaultFont,
                           customElements: [MarkdownElement] = []) {
@@ -94,15 +94,15 @@ open class MarkdownParser {
     self.font = font
     self.color = color
     
-    header = MarkdownHeader(font: font)
-    list = MarkdownList(font: font)
-    quote = MarkdownQuote(font: font)
-    link = MarkdownLink(font: font)
-    automaticLink = MarkdownAutomaticLink(font: font)
-    bold = MarkdownBold(font: font)
-    italic = MarkdownItalic(font: font)
-    code = MarkdownCode(font: font)
-    strikethrough = MarkdownStrikethrough(font: font)
+    self.header = MarkdownHeader(font: font)
+    self.list = MarkdownList(font: font)
+    self.quote = MarkdownQuote(font: font)
+    self.link = MarkdownLink(font: font)
+    self.automaticLink = MarkdownAutomaticLink(font: font)
+    self.bold = MarkdownBold(font: font)
+    self.italic = MarkdownItalic(font: font)
+    self.code = MarkdownCode(font: font)
+    self.strikethrough = MarkdownStrikethrough(font: font)
 
     self.escapingElements = [codeEscaping, escaping]
     self.unescapingElements = [code, unescaping]
@@ -113,23 +113,20 @@ open class MarkdownParser {
     updateUnescapingElements()
   }
 
+  // MARK: Element Extensibility
   public func replaceDefaultElement<E: MarkdownElement>(_ defaultElement: E.Type, with element: MarkdownElement) {
     guard let index = defaultElements.firstIndex(where: { $0 is E }) else { return }
 	defaultElements[index] = element
   }
-  
-  // MARK: Element Extensibility
+
   open func addCustomElement(_ element: MarkdownElement) {
     customElements.append(element)
   }
   
   open func removeCustomElement(_ element: MarkdownElement) {
-    guard let index = customElements.firstIndex(where: { someElement -> Bool in
-      return element === someElement
-    }) else {
-      return
+    if let index = customElements.firstIndex(where: { $0 === element }) {
+      customElements.remove(at: index)
     }
-    customElements.remove(at: index)
   }
   
   // MARK: Parsing
@@ -154,6 +151,7 @@ open class MarkdownParser {
   }
 
   fileprivate func updateDefaultElements() {
+    // Parsing order matters!
     let pairs: [(EnabledElements, MarkdownElement)] = [
       (.header, header),
       (.list, list),

--- a/MarkdownKit/Sources/Common/MarkdownParser.swift
+++ b/MarkdownKit/Sources/Common/MarkdownParser.swift
@@ -114,8 +114,8 @@ open class MarkdownParser {
   }
 
   // MARK: Element Extensibility
-  public func replaceDefaultElement<E: MarkdownElement>(_ defaultElement: E.Type, with element: MarkdownElement) {
-    guard let index = defaultElements.firstIndex(where: { $0 is E }) else { return }
+  public func replaceDefaultElement(_ defaultElement: MarkdownElement, with element: MarkdownElement) {
+    guard let index = defaultElements.firstIndex(where: { $0 === defaultElement }) else { return }
 	defaultElements[index] = element
   }
 

--- a/MarkdownKit/Sources/Common/Protocols/MarkdownLinkElement.swift
+++ b/MarkdownKit/Sources/Common/Protocols/MarkdownLinkElement.swift
@@ -11,5 +11,5 @@ import Foundation
 public protocol MarkdownLinkElement: MarkdownElement, MarkdownStyle {
   
   func formatText(_ attributedString: NSMutableAttributedString, range: NSRange, link: String)
-  func addAttributes(_ attributedString: NSMutableAttributedString, range: NSRange, link: String)
+  func addAttributes(_ attributedString: NSMutableAttributedString, range: NSRange)
 }

--- a/MarkdownKit/Sources/Common/Protocols/MarkdownStyle.swift
+++ b/MarkdownKit/Sources/Common/Protocols/MarkdownStyle.swift
@@ -11,11 +11,10 @@ import Foundation
 public protocol MarkdownStyle {
   var font: MarkdownFont? { get }
   var color: MarkdownColor? { get }
-    var attributes: [NSAttributedString.Key: AnyObject] { get }
+  var attributes: [NSAttributedString.Key: AnyObject] { get }
 }
 
 public extension MarkdownStyle {
-  
     var attributes: [NSAttributedString.Key: AnyObject] {
         var attributes = [NSAttributedString.Key: AnyObject]()
     if let font = font {
@@ -26,5 +25,4 @@ public extension MarkdownStyle {
     }
     return attributes
   }
-  
 }

--- a/MarkdownKit/Tests/MarkdownParserTests.swift
+++ b/MarkdownKit/Tests/MarkdownParserTests.swift
@@ -145,8 +145,9 @@ class Tests: XCTestCase {
             Link(title: "Lin(k", url: "http://example.com/test.html"),
             Link(title: "Lin(k", url: "http://example.com/test.html", prefix: "((("),
             Link(title: "Lin(k", url: "http://example.com/test.html", suffix: ")))"),
-            Link(title: "Lin(k", url: "http://example.com/test.html", prefix: "((", suffix: "))"),
+            Link(title: "Lin(k", url: "http://example.com/tes(t).html", prefix: "((", suffix: "))"),
             Link(title: "Lin(k", url: "http://example.com/test.html", prefix: "(", suffix: "))))"),
+            Link(title: "Lin(k", url: "http://example.com/test.html", prefix: "wwc(", suffix: ")w)ss))"),
             Link(title: "Li)nk", url: "http://example.com/test.html"),
             Link(title: "(Link)", url: "http://example.com/test.html")
         ]


### PR DESCRIPTION
**This is included**

- I'm checking if the url has any scheme, instead of just looking if it starts with http
- I fixed the parentheses balancing function
- A default scheme can now be set for links
- I preserve the current attributes of nested elements 
- Refactoring (wrong indentation etc.)
- More unit tests

I'm asking myself if the parentheses balancing function and/or the scheme detection should be opt in.

**Beyond this PR**

The styling of the Markdown elements is flawed. It would be better to lift the styles out of the elements and implement a rule based system on the top level to give the user more control (parsing order independent).

For example:

- Define font for heading and body on the top level
- Color definition for combinations like boldItalic, or
- applying weight to the elements (bold = 2, italic = 1 => use bold color)

This would be a breaking change though