### PR TITLE
Change protocol inheritance from class to AnyObject

### DIFF
--- a/MarkdownKit/Sources/Common/Protocols/MarkdownElement.swift
+++ b/MarkdownKit/Sources/Common/Protocols/MarkdownElement.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// The base protocol for all Markdown Elements, it handles parsing through regex.
-public protocol MarkdownElement: class {
+public protocol MarkdownElement: AnyObject {
   
   var regex: String { get }
   


### PR DESCRIPTION
Fixes deprecated warning for using `class` instead of `AnyObject`.