### PR TITLE
Fix a crash when parsing lists with lots of spaces after the indicator character

### DIFF
--- a/MarkdownKit/Sources/Common/Elements/List/MarkdownList.swift
+++ b/MarkdownKit/Sources/Common/Elements/List/MarkdownList.swift
@@ -38,7 +38,8 @@ open class MarkdownList: MarkdownLevelElement {
       let offset = levelIndicatorOffsetList[level] else { return }
     let indicator = "\(offset)\(indicatorIcon)"
     attributedString.replaceCharacters(in: range, with: indicator)
-    attributedString.addAttributes([.paragraphStyle : defaultParagraphStyle()], range: range)
+    let updatedRange = NSRange(location: range.location, length: indicator.utf16.count)
+    attributedString.addAttributes([.paragraphStyle : defaultParagraphStyle()], range: updatedRange)
   }
 
   private func defaultParagraphStyle() -> NSMutableParagraphStyle {

--- a/MarkdownKit/Tests/MarkdownParserTests.swift
+++ b/MarkdownKit/Tests/MarkdownParserTests.swift
@@ -218,6 +218,18 @@ class Tests: XCTestCase {
         XCTAssertEqual(attributedString.link, "https://" + link.url)
         XCTAssertNil(sut.link.defaultScheme)
     }
+
+    func testParseSimpleList() {
+        let markdown = "* first item\n* second item"
+        let attributedString = sut.parse(markdown)
+        XCTAssertTrue(attributedString.string.contains(sut.list.separator))
+    }
+
+    func testParseListWithLotsOfSpacesAfterIndicator() {
+        let markdown = "*                                 first item\n*   second item"
+        let attributedString = sut.parse(markdown)
+        XCTAssertTrue(attributedString.string.contains(sut.list.separator))
+    }
 }
 
 fileprivate extension MarkdownFont {


### PR DESCRIPTION
The range used in `.addAttributes()` is wrong, because we're replacing characters of the same range with the `indicator` variable right before, and the `indicator` can be shorter than the original `range.length`.

If the original range was sufficiently long for its length to be greater than the string's length after the indicator replacement, `.addAttributes` will crash.

Attached is a proposed fix and two simple tests, one passing and one failing before fix, both passing after.